### PR TITLE
introduce CakePHP CodeSniffer for PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "intervention/image": "^2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.3"
+        "phpunit/phpunit": "^8.5 || ^9.3",
+        "cakephp/cakephp-codesniffer": "^4.5"
     },
     "autoload": {
         "psr-4": {
@@ -24,6 +25,15 @@
         "psr-4": {
             "Assets\\Test\\": "tests/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
+        }
+    },
+    "scripts": {
+        "cs-check": "phpcs --colors --parallel=16 -p src/",
+        "cs-fix": "phpcbf --colors --parallel=16 -p src/"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="CakePHP DebugKit">
+  <config name="installed_paths" value="../../cakephp/cakephp-codesniffer" />
+
+  <rule ref="CakePHP" />
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="150"/>
+    </properties>
+  </rule>
+</ruleset>

--- a/src/Controller/Admin/AssetsController.php
+++ b/src/Controller/Admin/AssetsController.php
@@ -51,8 +51,8 @@ class AssetsController extends AppController
     public function add()
     {
         $asset = $this->Assets->newEmptyEntity();
-        if ($this->request->is('post')) {
-            $asset = $this->Assets->patchEntity($asset, $this->request->getData());
+        if ($this->getRequest()->is('post')) {
+            $asset = $this->Assets->patchEntity($asset, $this->getRequest()->getData());
             if ($this->Assets->save($asset)) {
                 $this->Flash->success(__('The asset has been saved.'));
 
@@ -75,8 +75,8 @@ class AssetsController extends AppController
         $asset = $this->Assets->get($id, [
             'contain' => [],
         ]);
-        if ($this->request->is(['patch', 'post', 'put'])) {
-            $asset = $this->Assets->patchEntity($asset, $this->request->getData());
+        if ($this->getRequest()->is(['patch', 'post', 'put'])) {
+            $asset = $this->Assets->patchEntity($asset, $this->getRequest()->getData());
             if ($this->Assets->save($asset)) {
                 $this->Flash->success(__('The asset has been saved.'));
 
@@ -96,7 +96,7 @@ class AssetsController extends AppController
      */
     public function delete($id = null)
     {
-        $this->request->allowMethod(['post', 'delete']);
+        $this->getRequest()->allowMethod(['post', 'delete']);
         $asset = $this->Assets->get($id);
         if ($this->Assets->delete($asset)) {
             $this->Flash->success(__('The asset has been deleted.'));
@@ -109,6 +109,9 @@ class AssetsController extends AppController
 
     /**
      * Add ?download=1 to URL to download instead of view the file.
+     *
+     * @param string $id The ID of the asset
+     * @return \Cake\Http\Response
      */
     public function download(string $id): Response
     {
@@ -119,7 +122,7 @@ class AssetsController extends AppController
             return $asset->read();
         });
 
-        $response = $this->response
+        $response = $this->getResponse()
             ->withType($asset->mimetype)
             ->withDisabledCache()
             ->withBody($stream);

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -5,8 +5,21 @@ namespace Assets\Controller;
 
 use App\Controller\AppController as BaseController;
 
+/**
+ * @mixin \Cake\Controller\Controller
+ */
 class AppController extends BaseController
 {
+    /**
+     * @var \Assets\Model\Table\AssetsTable
+     */
+    public $Assets;
+
+    /**
+     * Initialize the Assets table object
+     *
+     * @return void
+     */
     public function initialize(): void
     {
         parent::initialize();

--- a/src/Enum/ImageSizes.php
+++ b/src/Enum/ImageSizes.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace Assets\Enum;
 
 class ImageSizes
 {
-    const THMB = 75;
-    const SM = 120;
-    const MD = 230;
-    const LG = 520;
-    const XL = 750;
-    const XXL = 1250;
-    const HD = 1920;
+    public const THMB = 75;
+    public const SM = 120;
+    public const MD = 230;
+    public const LG = 520;
+    public const XL = 750;
+    public const XXL = 1250;
+    public const HD = 1920;
 }

--- a/src/Error/FileNotFoundException.php
+++ b/src/Error/FileNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+class FileNotFoundException extends \Exception
+{
+}

--- a/src/Error/FilterNotFoundException.php
+++ b/src/Error/FilterNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+class FilterNotFoundException extends \Exception
+{
+}

--- a/src/Error/InvalidArgumentException.php
+++ b/src/Error/InvalidArgumentException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+class InvalidArgumentException extends \Exception
+{
+}

--- a/src/Error/InvalidAssetTypeException.php
+++ b/src/Error/InvalidAssetTypeException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+class InvalidAssetTypeException extends \Exception
+{
+}

--- a/src/Error/UnkownErrorException.php
+++ b/src/Error/UnkownErrorException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+class UnkownErrorException extends \Exception
+{
+}

--- a/src/Model/Behavior/BelongsToAssetsBehavior.php
+++ b/src/Model/Behavior/BelongsToAssetsBehavior.php
@@ -7,7 +7,6 @@ use Assets\Model\Entity\Asset;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
-use Laminas\Diactoros\UploadedFile;
 
 /**
  * BelongsToAssets behavior
@@ -21,13 +20,23 @@ class BelongsToAssetsBehavior extends Behavior
      */
     protected $_defaultConfig = [];
 
-    public function beforeSave(EventInterface $event, EntityInterface $entity, $options): bool
+    /**
+     * @param \Cake\Event\EventInterface $event The beforeSave event
+     * @param \Cake\Datasource\EntityInterface $entity The entity related to the event
+     * @param \ArrayObject $options Options passed to the event
+     * @return bool
+     */
+    public function beforeSave(EventInterface $event, EntityInterface $entity, \ArrayObject $options): bool
     {
         $this->handleEmptyAssets($entity);
 
         return true;
     }
 
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity The entity
+     * @return void
+     */
     private function handleEmptyAssets(EntityInterface $entity)
     {
         foreach ($entity->toArray() as $key => $item) {
@@ -36,7 +45,7 @@ class BelongsToAssetsBehavior extends Behavior
             }
 
             /**
-             * @var UploadedFile $file
+             * @var \Laminas\Diactoros\UploadedFile $file
              */
             $file = $item['filename'];
             if (!$file->getClientFilename()) {

--- a/src/Model/Table/AssetsTable.php
+++ b/src/Model/Table/AssetsTable.php
@@ -8,7 +8,6 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 use Laminas\Diactoros\UploadedFile;
@@ -29,7 +28,6 @@ use Laminas\Diactoros\UploadedFile;
  * @method \Assets\Model\Entity\Asset[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
  * @method \Assets\Model\Entity\Asset[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
  * @method \Assets\Model\Entity\Asset[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
- *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */
 class AssetsTable extends Table
@@ -52,8 +50,7 @@ class AssetsTable extends Table
 
         $this->addBehavior('Josegonzalez/Upload.Upload', [
             'filename' => [
-                'nameCallback' => function ($table, EntityInterface $entity, UploadedFile $data, $field, $settings
-                ): string {
+                'nameCallback' => function ($table, EntityInterface $entity, UploadedFile $data, $field, $settings): string {
 
                     if (method_exists($this, 'fileNameCallback')) {
                         return $this->fileNameCallback($table, $entity, $data, $field, $settings);
@@ -120,11 +117,20 @@ class AssetsTable extends Table
         return $validator;
     }
 
-    public function beforeFind(EventInterface $e, Query $query, \ArrayObject $options, $primary)
+    /**
+     * @param \Cake\Event\EventInterface $e The event
+     * @param \Cake\ORM\Query $query The query associated to the event
+     * @param \ArrayObject $options Options passed to the event
+     * @return \Cake\ORM\Query
+     */
+    public function beforeFind(EventInterface $e, Query $query, \ArrayObject $options)
     {
         return $query->orderDesc('modified');
     }
 
+    /**
+     * @return string
+     */
     public static function getAssetsDir(): string
     {
         return Configure::read('AssetsPlugin.AssetsTable.assetsDir');
@@ -137,8 +143,10 @@ class AssetsTable extends Table
      * See AssetsTable::initialize()
      *
      * You can also define methods like beforeFind() or afterSave()
+     *
      * @link https://book.cakephp.org/4/en/orm/table-objects.html#lifecycle-callbacks
      * @link https://book.cakephp.org/4/en/orm/behaviors.html
+     * @return void
      */
     private function addCustomBehaviors()
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,6 +28,11 @@ class Plugin extends BasePlugin
         $app->addPlugin('Josegonzalez/Upload');
     }
 
+    /**
+     * Loads the config from the user
+     *
+     * @return void
+     */
     private function loadConfig(): void
     {
         Configure::load('Assets.app_assets');

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -1,19 +1,14 @@
 <?php
+declare(strict_types=1);
 
 namespace Assets\View;
 
-use Assets\View\Helper\PictureHelper;
-use Assets\View\Helper\TextAssetPreviewHelper;
 use Cake\View\View;
 
 /**
- * @property TextAssetPreviewHelper $TextAssetPreview
- * @property PictureHelper $Picture
+ * @property \Assets\View\Helper\TextAssetPreviewHelper $TextAssetPreview
+ * @property \Assets\View\Helper\PictureHelper $Picture
  */
 class AppView extends View
 {
-    public function initialize(): void
-    {
-        parent::initialize();
-    }
 }

--- a/src/View/Helper/TextAssetPreviewHelper.php
+++ b/src/View/Helper/TextAssetPreviewHelper.php
@@ -18,6 +18,11 @@ class TextAssetPreviewHelper extends Helper
      */
     protected $_defaultConfig = [];
 
+    /**
+     * @param \Assets\Model\Entity\Asset $asset The asset entity
+     * @param array $options Options passed to the CSV Reader
+     * @return string
+     */
     public function plainTextPreview(Asset $asset, array $options = []): string
     {
         if (!$asset->exists()) {
@@ -32,16 +37,28 @@ class TextAssetPreviewHelper extends Helper
                     return $this->printFormatted($asset);
             }
         } catch (\Exception $e) {
-            return __d('assets', "Error at TextAssetPreviewHelper: The Asset #{$asset->id}'s file with the filetype {$asset->filetype} is not readable. ");
+            return __d('assets', "Error at TextAssetPreviewHelper: The Asset #{$asset->id}'s 
+            file with the filetype {$asset->filetype} is not readable. ");
         }
-
     }
 
+    /**
+     * @param \Assets\Model\Entity\Asset $asset The asset entity
+     * @return string
+     * @throws \Exception
+     */
     private function printFormatted(Asset $asset): string
     {
-        return "<pre>" . h($asset->read()) . "</pre>";
+        return '<pre>' . h($asset->read()) . '</pre>';
     }
 
+    /**
+     * @param \Assets\Model\Entity\Asset $asset The asset entity
+     * @param array $options Options passed to the CSV Reader
+     * @return string
+     * @throws \League\Csv\Exception
+     * @throws \League\Csv\InvalidArgument
+     */
     private function csvPreview(Asset $asset, array $options = []): string
     {
         $reader = $asset->getCsvReader($options);


### PR DESCRIPTION
Well hello there 😄 

I really like where this plugin is heading but there are some tools missing which I would like to see 😉 
Therefore I started here with the CakePHP CodeSniffer which is default in all CakePHP installations and all plugins.

So if you want to check your code if its compliant with CakePHP coding style then just execute `composer cs-check` or `composer cs-fix` (after an initial `composer install` of course 😄 )

The most changes I made here were the PHPDoc blocks above each function.
Seems like you didn't know you can use PHPDoc blocks to comment arguments, return values etc. but thats no problem 😉
Since not all methods had comments above them I tried to add some usefull info to them but you can of course adapt that further down the line. 

The other thing I did was introduce custom Exception classes instead of throwing generic `/Exception`
I tried to make them not too complicated but I am happy if you got any further comments on that.

See bellow on the `getPath()` method why I think that last exception is not really necessary.