### PR TITLE
add phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3",
-        "cakephp/cakephp-codesniffer": "^4.5"
+        "cakephp/cakephp-codesniffer": "^4.5",
+        "cakedc/cakephp-phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -25,12 +26,15 @@
     "autoload-dev": {
         "psr-4": {
             "Assets\\Test\\": "tests/",
+            "TestApp\\": "tests/test_app/src/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
     },
     "scripts": {
         "cs-check": "phpcs --colors --parallel=16 -p src/",
-        "cs-fix": "phpcbf --colors --parallel=16 -p src/"
+        "cs-fix": "phpcbf --colors --parallel=16 -p src/",
+        "stan": "phpstan analyse",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.0 && mv composer.backup composer.json"
     },
     "config": {
         "allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+    level: 6
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
+    paths:
+        - src
+    bootstrapFiles:
+        - tests/bootstrap.php
+
+includes:
+	- vendor/cakedc/cakephp-phpstan/extension.neon

--- a/src/Model/Behavior/BelongsToAssetsBehavior.php
+++ b/src/Model/Behavior/BelongsToAssetsBehavior.php
@@ -16,7 +16,7 @@ class BelongsToAssetsBehavior extends Behavior
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 

--- a/src/Model/Entity/Asset.php
+++ b/src/Model/Entity/Asset.php
@@ -41,7 +41,7 @@ class Asset extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<bool>
      */
     protected $_accessible = [
         'title' => true,

--- a/src/Utilities/ImageAsset.php
+++ b/src/Utilities/ImageAsset.php
@@ -79,7 +79,8 @@ class ImageAsset
      * @param array $options - optional:
      * - title (string): for alt-parameter in html-output
      * - quality (int): for jpg compression
-     * @return $this
+     * @throws \Exception
+     * @return \Assets\Utilities\ImageAsset
      */
     public static function createFromPath(string $path, array $options = [])
     {
@@ -101,7 +102,7 @@ class ImageAsset
         $asset->id = md5($path);
         $asset->filename = $splFileInfo->getFilename();
         $asset->directory = ltrim(str_replace(ROOT, '', $splFileInfo->getPath()), DS);
-        $asset->mimetype = mime_content_type($absolute_path);
+        $asset->mimetype = mime_content_type($absolute_path) ?: 'unknown';
         $asset->title = $options['title'] ?? null;
         $asset->description = null;
         $asset->modified = FrozenTime::createFromTimestamp($splFileInfo->getMTime());

--- a/src/View/Helper/PictureHelper.php
+++ b/src/View/Helper/PictureHelper.php
@@ -18,7 +18,7 @@ class PictureHelper extends Helper
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 
@@ -106,10 +106,10 @@ class PictureHelper extends Helper
      * @param string $format Which type of image you want
      * @param array $widths Array of image widths you desire to have in the SrcSet
      * @param array $options - passed to PictureHelper::getImageUrl
-     * @return string|null
+     * @return string
      * @throws \Assets\Error\InvalidArgumentException
      */
-    private function getSrcSet(string $format, array $widths, array $options = []): ?string
+    private function getSrcSet(string $format, array $widths, array $options = []): string
     {
         $links = [];
 

--- a/src/View/Helper/TextAssetPreviewHelper.php
+++ b/src/View/Helper/TextAssetPreviewHelper.php
@@ -14,7 +14,7 @@ class TextAssetPreviewHelper extends Helper
     /**
      * Default configuration.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,125 @@
+<?php
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\Filesystem\Folder;
+use Cake\Mailer\TransportFactory;
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+if (!defined('WINDOWS')) {
+    if (DS === '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+        define('WINDOWS', true);
+    } else {
+        define('WINDOWS', false);
+    }
+}
+
+define('PLUGIN_ROOT', dirname(__DIR__));
+define('ROOT', PLUGIN_ROOT . DS . 'tests' . DS . 'test_app');
+define('TMP', PLUGIN_ROOT . DS . 'tmp' . DS);
+define('LOGS', TMP . 'logs' . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('APP', ROOT . DS . 'src' . DS);
+define('APP_DIR', 'src');
+define('CAKE_CORE_INCLUDE_PATH', PLUGIN_ROOT . '/vendor/cakephp/cakephp');
+define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
+define('CAKE', CORE_PATH . APP_DIR . DS);
+
+define('WWW_ROOT', PLUGIN_ROOT . DS . 'webroot' . DS);
+define('TESTS', __DIR__ . DS);
+define('CONFIG', TESTS . 'config' . DS);
+
+ini_set('intl.default_locale', 'de-DE');
+
+require PLUGIN_ROOT . '/vendor/autoload.php';
+require CORE_PATH . 'config/bootstrap.php';
+
+Configure::write('App', [
+    'namespace' => 'TestApp',
+    'encoding' => 'UTF-8',
+    'paths' => [
+        'templates' => [
+            PLUGIN_ROOT . DS . 'tests' . DS . 'test_app' . DS . 'templates' . DS,
+        ],
+    ],
+]);
+
+Configure::write('debug', true);
+
+Configure::write('EmailTransport', [
+    'default' => [
+        'className' => 'Debug',
+    ],
+]);
+Configure::write('Email', [
+    'default' => [
+        'transport' => 'default',
+        'from' => 'you@localhost',
+    ],
+]);
+
+mb_internal_encoding('UTF-8');
+
+$Tmp = new Folder(TMP);
+$Tmp->create(TMP . 'cache/models', 0770);
+$Tmp->create(TMP . 'cache/persistent', 0770);
+$Tmp->create(TMP . 'cache/views', 0770);
+
+$cache = [
+    'default' => [
+        'engine' => 'File',
+        'path' => CACHE,
+    ],
+    '_cake_core_' => [
+        'className' => 'File',
+        'prefix' => 'crud_myapp_cake_core_',
+        'path' => CACHE . 'persistent/',
+        'serialize' => true,
+        'duration' => '+10 seconds',
+    ],
+    '_cake_model_' => [
+        'className' => 'File',
+        'prefix' => 'crud_my_app_cake_model_',
+        'path' => CACHE . 'models/',
+        'serialize' => 'File',
+        'duration' => '+10 seconds',
+    ],
+];
+
+Cache::setConfig($cache);
+
+class_alias(TestApp\Controller\AppController::class, 'App\Controller\AppController');
+
+TransportFactory::setConfig('default', [
+    'className' => 'Debug',
+]);
+
+// Allow local overwrite
+// E.g. in your console: export DB_URL="mysql://root:secret@127.0.0.1/cake_test"
+if (getenv('DB_URL')) {
+    ConnectionManager::setConfig('test', [
+        'url' => getenv('DB_URL'),
+        'quoteIdentifiers' => false,
+        'cacheMetadata' => true,
+    ]);
+
+    return;
+}
+
+if (!getenv('DB_CLASS')) {
+    putenv('DB_CLASS=Cake\Database\Driver\Sqlite');
+    putenv('DB_URL=sqlite:///:memory:');
+}
+
+// Uses Travis config then (MySQL, Postgres, ...)
+ConnectionManager::setConfig('test', [
+    'className' => 'Cake\Database\Connection',
+    'driver' => getenv('DB_CLASS') ?: null,
+    'dsn' => getenv('DB_URL') ?: null,
+    'timezone' => 'UTC',
+    'quoteIdentifiers' => false,
+    'cacheMetadata' => true,
+]);

--- a/tests/test_app/src/Controller/AppController.php
+++ b/tests/test_app/src/Controller/AppController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class AppController extends Controller {
+
+    /**
+     * @return void
+     */
+    public function initialize(): void {
+        parent::initialize();
+
+        $this->loadComponent('Flash');
+    }
+
+}


### PR DESCRIPTION
Well, here goes the next utility 😄 What did I do to make this work?

Well, I basically added the `stan-setup` command like they are present in any other cakephp repo and tried to make it run.

But since phpstan needs a bootstraped cakephp and you have no tests (yet) I basically copied and adjusted the `tests/bootstrap.php` from https://github.com/dereuromark/cakephp-queue/blob/master/tests/bootstrap.php

The `tests/test_app/src/Controller/AppController.php` part was needed so your 
```
use App\Controller\AppController as BaseController;
```
works without it having to be installed in an app.

You got any plans to start creating some phpunit tests?