### PR TITLE
Use Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,30 +67,30 @@ jobs:
           fi
           if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then composer lowest-setup; fi
 
-      - name: Setup problem matchers for PHPUnit
-        if: matrix.db-type == 'mysql'
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+#      - name: Setup problem matchers for PHPUnit
+#        if: matrix.db-type == 'mysql'
+#        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Wait for MySQL
-        if: matrix.db-type == 'mysql'
-        run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
+#      - name: Wait for MySQL
+#        if: matrix.db-type == 'mysql'
+#        run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
 
-      - name: Run PHPUnit
-        run: |
-          if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
-          if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
-          if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-          if [[ ${{ matrix.php-version }} == '7.3' && ${{ matrix.db-type }} == 'sqlite' ]]; then
-            vendor/bin/phpunit --coverage-clover=coverage.xml
-          else
-            vendor/bin/phpunit
-          fi
+#      - name: Run PHPUnit
+#        run: |
+#          if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
+#          if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
+#          if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
+#          if [[ ${{ matrix.php-version }} == '7.3' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+#            vendor/bin/phpunit --coverage-clover=coverage.xml
+#          else
+#            vendor/bin/phpunit
+#          fi
 
       - name: Validate prefer-lowest
         run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
       - name: Code Coverage Report
-        if: success() && matrix.php-version == '7.3' && matrix.db-type == 'sqlite'
+        if: success() && matrix.php-version == '7.4' && matrix.db-type == 'sqlite'
         uses: codecov/codecov-action@v1
 
   validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  testsuite:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.1']
+        db-type: ['sqlite', 'mysql', 'pgsql']
+        prefer-lowest: ['']
+        include:
+          - php-version: '7.4'
+            db-type: 'sqlite'
+            prefer-lowest: 'prefer-lowest'
+
+    services:
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Service
+        if: matrix.db-type == 'mysql'
+        run: |
+          sudo service mysql start
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp;'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, intl, pdo_${{ matrix.db-type }}
+          coverage: pcov
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Composer install --no-progress --prefer-dist --optimize-autoloader
+        run: |
+          composer --version
+          if ${{ matrix.prefer-lowest == 'prefer-lowest' }}
+          then
+            composer update --prefer-lowest --prefer-stable
+          else
+            composer install --no-progress --prefer-dist --optimize-autoloader
+          fi
+          if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then composer lowest-setup; fi
+
+      - name: Setup problem matchers for PHPUnit
+        if: matrix.db-type == 'mysql'
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Wait for MySQL
+        if: matrix.db-type == 'mysql'
+        run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
+
+      - name: Run PHPUnit
+        run: |
+          if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
+          if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
+          if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
+          if [[ ${{ matrix.php-version }} == '7.3' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+            vendor/bin/phpunit --coverage-clover=coverage.xml
+          else
+            vendor/bin/phpunit
+          fi
+
+      - name: Validate prefer-lowest
+        run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
+
+      - name: Code Coverage Report
+        if: success() && matrix.php-version == '7.3' && matrix.db-type == 'sqlite'
+        uses: codecov/codecov-action@v1
+
+  validation:
+    name: Coding Standard & Static Analysis
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Composer phpstan setup
+        run: composer stan-setup
+
+      - name: Run phpstan
+        run: vendor/bin/phpstan analyse --error-format=github
+
+      - name: Run phpcs
+        run: composer cs-check

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "cs-check": "phpcs --colors --parallel=16 -p src/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/",
         "stan": "phpstan analyse",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.9 && mv composer.backup composer.json",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "cs-check": "phpcs --colors --parallel=16 -p src/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/",
         "stan": "phpstan analyse",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.0 && mv composer.backup composer.json"
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.0 && mv composer.backup composer.json",
+        "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Next up we can enable Github Actions to perform at least the checks/tests we already have, which are 
- `composer cs-check`
- `composer stan`

The PHP Matrix for 7.4 and 8.1 is there but its only installing the dependencies defined in your composer.json so nothing really usefull happens there since we don't have tests (yet)

You are of course free to adjust the tested DB types or PHP versions.