### PR TITLE
use __d() translate function and generate assets.pot file

### DIFF
--- a/resources/locales/assets.pot
+++ b/resources/locales/assets.pot
@@ -1,0 +1,177 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2022-11-23 22:09+0100\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: src/Controller/Admin/AssetsController.php:57
+#: src/Controller/Admin/AssetsController.php:81
+msgid "The asset has been saved."
+msgstr ""
+
+#: src/Controller/Admin/AssetsController.php:61
+#: src/Controller/Admin/AssetsController.php:85
+msgid "The asset could not be saved. Please, try again."
+msgstr ""
+
+#: src/Controller/Admin/AssetsController.php:102
+msgid "The asset has been deleted."
+msgstr ""
+
+#: src/Controller/Admin/AssetsController.php:104
+msgid "The asset could not be deleted. Please, try again."
+msgstr ""
+
+#: src/Model/Entity/Asset.php:174
+msgid "File not found."
+msgstr ""
+
+#: src/Model/Entity/Asset.php:183
+msgid "Cannot get ImageAsset."
+msgstr ""
+
+#: src/View/Helper/TextAssetPreviewHelper.php:29
+msgid "The Asset's file does not exist."
+msgstr ""
+
+#: src/View/Helper/TextAssetPreviewHelper.php:40
+msgid "Error at TextAssetPreviewHelper: The Asset #{0}'s file with the filetype {1} is not readable."
+msgstr ""
+
+#: templates/Admin/Assets/add.php:10
+#: templates/Admin/Assets/edit.php:10
+#: templates/Admin/Assets/index.php:27
+#: templates/Admin/Assets/view.php:10
+msgid "Actions"
+msgstr ""
+
+#: templates/Admin/Assets/add.php:11
+#: templates/Admin/Assets/edit.php:16
+#: templates/Admin/Assets/view.php:14
+msgid "List Assets"
+msgstr ""
+
+#: templates/Admin/Assets/add.php:18
+msgid "Add Asset"
+msgstr ""
+
+#: templates/Admin/Assets/add.php:26
+#: templates/Admin/Assets/edit.php:33
+msgid "Submit"
+msgstr ""
+
+#: templates/Admin/Assets/edit.php:12
+#: templates/Admin/Assets/index.php:62
+msgid "Delete"
+msgstr ""
+
+#: templates/Admin/Assets/edit.php:14
+#: templates/Admin/Assets/index.php:62
+#: templates/Admin/Assets/view.php:13
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+#: templates/Admin/Assets/edit.php:23
+#: templates/Admin/Assets/view.php:11
+msgid "Edit Asset"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:8
+#: templates/Admin/Assets/view.php:15
+msgid "New Asset"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:9
+msgid "Assets"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:26
+msgid "Preview"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:60
+msgid "View"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:61
+msgid "Edit"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:71
+msgid "first"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:72
+msgid "previous"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:74
+msgid "next"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:75
+msgid "last"
+msgstr ""
+
+#: templates/Admin/Assets/index.php:78
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:12
+msgid "Delete Asset"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:28
+msgid "Id"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:32
+msgid "Title"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:36
+msgid "Category"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:40
+msgid "Filename"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:44
+msgid "Directory"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:48
+msgid "Mimetype"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:52
+msgid "Filesize"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:56
+msgid "Created"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:60
+msgid "Modified"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:65
+msgid "Description"
+msgstr ""
+
+#: templates/Admin/Assets/view.php:72
+msgid "Content"
+msgstr ""
+

--- a/src/Controller/Admin/AssetsController.php
+++ b/src/Controller/Admin/AssetsController.php
@@ -6,7 +6,6 @@ namespace Assets\Controller\Admin;
 use Assets\Controller\AppController;
 use Cake\Http\CallbackStream;
 use Cake\Http\Response;
-use function __;
 
 /**
  * Assets Controller
@@ -54,11 +53,11 @@ class AssetsController extends AppController
         if ($this->getRequest()->is('post')) {
             $asset = $this->Assets->patchEntity($asset, $this->getRequest()->getData());
             if ($this->Assets->save($asset)) {
-                $this->Flash->success(__('The asset has been saved.'));
+                $this->Flash->success(__d('assets', 'The asset has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The asset could not be saved. Please, try again.'));
+            $this->Flash->error(__d('assets', 'The asset could not be saved. Please, try again.'));
         }
         $this->set(compact('asset'));
     }
@@ -78,11 +77,11 @@ class AssetsController extends AppController
         if ($this->getRequest()->is(['patch', 'post', 'put'])) {
             $asset = $this->Assets->patchEntity($asset, $this->getRequest()->getData());
             if ($this->Assets->save($asset)) {
-                $this->Flash->success(__('The asset has been saved.'));
+                $this->Flash->success(__d('assets', 'The asset has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The asset could not be saved. Please, try again.'));
+            $this->Flash->error(__d('assets', 'The asset could not be saved. Please, try again.'));
         }
         $this->set(compact('asset'));
     }
@@ -99,9 +98,9 @@ class AssetsController extends AppController
         $this->getRequest()->allowMethod(['post', 'delete']);
         $asset = $this->Assets->get($id);
         if ($this->Assets->delete($asset)) {
-            $this->Flash->success(__('The asset has been deleted.'));
+            $this->Flash->success(__d('assets', 'The asset has been deleted.'));
         } else {
-            $this->Flash->error(__('The asset could not be deleted. Please, try again.'));
+            $this->Flash->error(__d('assets', 'The asset could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Model/Entity/Asset.php
+++ b/src/Model/Entity/Asset.php
@@ -171,7 +171,7 @@ class Asset extends Entity
     public function getThumbnail(int $size = ImageSizes::THMB, bool $html = true): ?string
     {
         if (!$this->exists()) {
-            return __d('assets', 'File not found. ');
+            return __d('assets', 'File not found.');
         }
 
         if ($this->isImage()) {
@@ -180,7 +180,7 @@ class Asset extends Entity
 
                 return $html ? $thumbnail->getHTML() : $thumbnail->getPath();
             } catch (\Exception $e) {
-                return __d('assets', 'Cannot get ImageAsset. ');
+                return __d('assets', 'Cannot get ImageAsset.');
             }
         }
 

--- a/src/View/Helper/TextAssetPreviewHelper.php
+++ b/src/View/Helper/TextAssetPreviewHelper.php
@@ -26,7 +26,7 @@ class TextAssetPreviewHelper extends Helper
     public function plainTextPreview(Asset $asset, array $options = []): string
     {
         if (!$asset->exists()) {
-            return __('The Asset\'s file does not exist. ');
+            return __d('assets', 'The Asset\'s file does not exist.');
         }
 
         try {
@@ -37,8 +37,8 @@ class TextAssetPreviewHelper extends Helper
                     return $this->printFormatted($asset);
             }
         } catch (\Exception $e) {
-            return __d('assets', "Error at TextAssetPreviewHelper: The Asset #{$asset->id}'s 
-            file with the filetype {$asset->filetype} is not readable. ");
+            return __d('assets', "Error at TextAssetPreviewHelper: The Asset #{0}'s " .
+            'file with the filetype {1} is not readable.', $asset->id, $asset->filetype);
         }
     }
 

--- a/templates/Admin/Assets/add.php
+++ b/templates/Admin/Assets/add.php
@@ -7,15 +7,15 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __('Actions') ?></h4>
-            <?= $this->Html->link(__('List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
+            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
         <div class="assets form content">
             <?= $this->Form->create($asset, ['type' => 'file']) ?>
             <fieldset>
-                <legend><?= __('Add Asset') ?></legend>
+                <legend><?= __d('assets','Add Asset') ?></legend>
                 <?php
                     echo $this->Form->control('title');
                     echo $this->Form->control('description');
@@ -23,7 +23,7 @@
                     echo $this->Form->control('filename', ['type' => 'file']);
                 ?>
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('assets','Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Assets/add.php
+++ b/templates/Admin/Assets/add.php
@@ -7,15 +7,15 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
-            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <h4 class="heading"><?= __d('assets', 'Actions') ?></h4>
+            <?= $this->Html->link(__d('assets', 'List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
         <div class="assets form content">
             <?= $this->Form->create($asset, ['type' => 'file']) ?>
             <fieldset>
-                <legend><?= __d('assets','Add Asset') ?></legend>
+                <legend><?= __d('assets', 'Add Asset') ?></legend>
                 <?php
                     echo $this->Form->control('title');
                     echo $this->Form->control('description');
@@ -23,7 +23,7 @@
                     echo $this->Form->control('filename', ['type' => 'file']);
                 ?>
             </fieldset>
-            <?= $this->Form->button(__d('assets','Submit')) ?>
+            <?= $this->Form->button(__d('assets', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Assets/edit.php
+++ b/templates/Admin/Assets/edit.php
@@ -7,20 +7,20 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
+            <h4 class="heading"><?= __d('assets', 'Actions') ?></h4>
             <?= $this->Form->postLink(
-                __d('assets','Delete'),
+                __d('assets', 'Delete'),
                 ['action' => 'delete', $asset->id],
-                ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']
+                ['confirm' => __d('assets', 'Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']
             ) ?>
-            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets', 'List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
         <div class="assets form content">
             <?= $this->Form->create($asset, ['type' => 'file']) ?>
             <fieldset>
-                <legend><?= __d('assets','Edit Asset') ?></legend>
+                <legend><?= __d('assets', 'Edit Asset') ?></legend>
                 <?= $asset->getThumbnail() ?>
                 <?php
                     echo $this->Form->control('title');
@@ -30,7 +30,7 @@
                 ?>
 
             </fieldset>
-            <?= $this->Form->button(__d('assets','Submit')) ?>
+            <?= $this->Form->button(__d('assets', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Assets/edit.php
+++ b/templates/Admin/Assets/edit.php
@@ -7,20 +7,20 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __('Actions') ?></h4>
+            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
             <?= $this->Form->postLink(
-                __('Delete'),
+                __d('assets','Delete'),
                 ['action' => 'delete', $asset->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']
+                ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']
             ) ?>
-            <?= $this->Html->link(__('List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
         <div class="assets form content">
             <?= $this->Form->create($asset, ['type' => 'file']) ?>
             <fieldset>
-                <legend><?= __('Edit Asset') ?></legend>
+                <legend><?= __d('assets','Edit Asset') ?></legend>
                 <?= $asset->getThumbnail() ?>
                 <?php
                     echo $this->Form->control('title');
@@ -30,7 +30,7 @@
                 ?>
 
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('assets','Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Assets/index.php
+++ b/templates/Admin/Assets/index.php
@@ -5,8 +5,8 @@
  */
 ?>
 <div class="assets index content">
-    <?= $this->Html->link(__('New Asset'), ['action' => 'add'], ['class' => 'button float-right']) ?>
-    <h3><?= __('Assets') ?></h3>
+    <?= $this->Html->link(__d('assets','New Asset'), ['action' => 'add'], ['class' => 'button float-right']) ?>
+    <h3><?= __d('assets','Assets') ?></h3>
     <div class="table-responsive">
         <table>
             <thead>
@@ -23,8 +23,8 @@
                         <?= $this->Paginator->sort('created') ?> /
                         <?= $this->Paginator->sort('modified') ?>
                     </th>
-                    <th>Vorschau</th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th><?= __d('assets', 'Preview') ?></th>
+                    <th class="actions"><?= __d('assets','Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -57,9 +57,9 @@
                         <?= $this->Html->link($asset->getThumbnail() ?: 'Öffnen', ['action' => 'download', $asset->id, '?' => ['download' => $asset->isViewableInBrowser() ? 0 : 1]], ['escape' => false]) ?>
                     </td>
                     <td class="actions">
-                        <?= $this->Html->link(__('View'), ['action' => 'view', $asset->id]) ?>
-                        <?= $this->Html->link(__('Edit'), ['action' => 'edit', $asset->id]) ?>
-                        <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $asset->id], ['confirm' => __('Are you sure you want to delete # {0}?', $asset->id)]) ?>
+                        <?= $this->Html->link(__d('assets','View'), ['action' => 'view', $asset->id]) ?>
+                        <?= $this->Html->link(__d('assets','Edit'), ['action' => 'edit', $asset->id]) ?>
+                        <?= $this->Form->postLink(__d('assets','Delete'), ['action' => 'delete', $asset->id], ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id)]) ?>
                     </td>
                 </tr>
                 <?php endforeach; ?>
@@ -68,13 +68,13 @@
     </div>
     <div class="paginator">
         <ul class="pagination">
-            <?= $this->Paginator->first('<< ' . __('first')) ?>
-            <?= $this->Paginator->prev('< ' . __('previous')) ?>
+            <?= $this->Paginator->first('<< ' . __d('assets','first')) ?>
+            <?= $this->Paginator->prev('< ' . __d('assets','previous')) ?>
             <?= $this->Paginator->numbers() ?>
-            <?= $this->Paginator->next(__('next') . ' >') ?>
-            <?= $this->Paginator->last(__('last') . ' >>') ?>
+            <?= $this->Paginator->next(__d('assets','next') . ' >') ?>
+            <?= $this->Paginator->last(__d('assets','last') . ' >>') ?>
         </ul>
         <p><?= $this->Paginator->limitControl() ?></p>
-        <p><?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?></p>
+        <p><?= $this->Paginator->counter(__d('assets','Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?></p>
     </div>
 </div>

--- a/templates/Admin/Assets/index.php
+++ b/templates/Admin/Assets/index.php
@@ -5,8 +5,8 @@
  */
 ?>
 <div class="assets index content">
-    <?= $this->Html->link(__d('assets','New Asset'), ['action' => 'add'], ['class' => 'button float-right']) ?>
-    <h3><?= __d('assets','Assets') ?></h3>
+    <?= $this->Html->link(__d('assets', 'New Asset'), ['action' => 'add'], ['class' => 'button float-right']) ?>
+    <h3><?= __d('assets', 'Assets') ?></h3>
     <div class="table-responsive">
         <table>
             <thead>
@@ -24,7 +24,7 @@
                         <?= $this->Paginator->sort('modified') ?>
                     </th>
                     <th><?= __d('assets', 'Preview') ?></th>
-                    <th class="actions"><?= __d('assets','Actions') ?></th>
+                    <th class="actions"><?= __d('assets', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -57,9 +57,9 @@
                         <?= $this->Html->link($asset->getThumbnail() ?: 'Öffnen', ['action' => 'download', $asset->id, '?' => ['download' => $asset->isViewableInBrowser() ? 0 : 1]], ['escape' => false]) ?>
                     </td>
                     <td class="actions">
-                        <?= $this->Html->link(__d('assets','View'), ['action' => 'view', $asset->id]) ?>
-                        <?= $this->Html->link(__d('assets','Edit'), ['action' => 'edit', $asset->id]) ?>
-                        <?= $this->Form->postLink(__d('assets','Delete'), ['action' => 'delete', $asset->id], ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id)]) ?>
+                        <?= $this->Html->link(__d('assets', 'View'), ['action' => 'view', $asset->id]) ?>
+                        <?= $this->Html->link(__d('assets', 'Edit'), ['action' => 'edit', $asset->id]) ?>
+                        <?= $this->Form->postLink(__d('assets', 'Delete'), ['action' => 'delete', $asset->id], ['confirm' => __d('assets', 'Are you sure you want to delete # {0}?', $asset->id)]) ?>
                     </td>
                 </tr>
                 <?php endforeach; ?>
@@ -68,13 +68,13 @@
     </div>
     <div class="paginator">
         <ul class="pagination">
-            <?= $this->Paginator->first('<< ' . __d('assets','first')) ?>
-            <?= $this->Paginator->prev('< ' . __d('assets','previous')) ?>
+            <?= $this->Paginator->first('<< ' . __d('assets', 'first')) ?>
+            <?= $this->Paginator->prev('< ' . __d('assets', 'previous')) ?>
             <?= $this->Paginator->numbers() ?>
-            <?= $this->Paginator->next(__d('assets','next') . ' >') ?>
-            <?= $this->Paginator->last(__d('assets','last') . ' >>') ?>
+            <?= $this->Paginator->next(__d('assets', 'next') . ' >') ?>
+            <?= $this->Paginator->last(__d('assets', 'last') . ' >>') ?>
         </ul>
         <p><?= $this->Paginator->limitControl() ?></p>
-        <p><?= $this->Paginator->counter(__d('assets','Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?></p>
+        <p><?= $this->Paginator->counter(__d('assets', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?></p>
     </div>
 </div>

--- a/templates/Admin/Assets/view.php
+++ b/templates/Admin/Assets/view.php
@@ -7,12 +7,12 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __('Actions') ?></h4>
-            <?= $this->Html->link(__('Edit Asset'), ['action' => 'edit', $asset->id], ['class' => 'side-nav-item']) ?>
-            <?= $this->Form->postLink(__('Delete Asset'), ['action' => 'delete', $asset->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']) ?>
-            <?= $this->Html->link(__('List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
-            <?= $this->Html->link(__('New Asset'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
+            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
+            <?= $this->Html->link(__d('assets','Edit Asset'), ['action' => 'edit', $asset->id], ['class' => 'side-nav-item']) ?>
+            <?= $this->Form->postLink(__d('assets','Delete Asset'), ['action' => 'delete', $asset->id],
+                ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets','New Asset'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
@@ -25,51 +25,51 @@
             <?php endif; ?>
             <table>
                 <tr>
-                    <th><?= __('Id') ?></th>
+                    <th><?= __d('assets','Id') ?></th>
                     <td><?= h($asset->id) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Title') ?></th>
+                    <th><?= __d('assets','Title') ?></th>
                     <td><?= h($asset->title) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Category') ?></th>
+                    <th><?= __d('assets','Category') ?></th>
                     <td><?= h($asset->category) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Filename') ?></th>
+                    <th><?= __d('assets','Filename') ?></th>
                     <td><?= h($asset->filename) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Directory') ?></th>
+                    <th><?= __d('assets','Directory') ?></th>
                     <td><?= h($asset->directory) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Mimetype') ?></th>
+                    <th><?= __d('assets','Mimetype') ?></th>
                     <td><?= h($asset->mimetype) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Filesize') ?></th>
+                    <th><?= __d('assets','Filesize') ?></th>
                     <td><?= h($asset->getFileSizeInfo()) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Created') ?></th>
+                    <th><?= __d('assets','Created') ?></th>
                     <td><?= h($asset->created) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Modified') ?></th>
+                    <th><?= __d('assets','Modified') ?></th>
                     <td><?= h($asset->modified) ?></td>
                 </tr>
             </table>
             <div class="text">
-                <strong><?= __('Description') ?></strong>
+                <strong><?= __d('assets','Description') ?></strong>
                 <blockquote>
                     <?= h($asset->description); ?>
                 </blockquote>
             </div>
             <?php if ($asset->isPlainText()): ?>
                 <div class="text">
-                    <strong><?= __('Inhalt') ?></strong>
+                    <strong><?= __d('assets','Content') ?></strong>
                     <div>
                         <?= $this->TextAssetPreview->plainTextPreview($asset) ?>
                     </div>

--- a/templates/Admin/Assets/view.php
+++ b/templates/Admin/Assets/view.php
@@ -7,12 +7,12 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __d('assets','Actions') ?></h4>
-            <?= $this->Html->link(__d('assets','Edit Asset'), ['action' => 'edit', $asset->id], ['class' => 'side-nav-item']) ?>
-            <?= $this->Form->postLink(__d('assets','Delete Asset'), ['action' => 'delete', $asset->id],
-                ['confirm' => __d('assets','Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']) ?>
-            <?= $this->Html->link(__d('assets','List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
-            <?= $this->Html->link(__d('assets','New Asset'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
+            <h4 class="heading"><?= __d('assets', 'Actions') ?></h4>
+            <?= $this->Html->link(__d('assets', 'Edit Asset'), ['action' => 'edit', $asset->id], ['class' => 'side-nav-item']) ?>
+            <?= $this->Form->postLink(__d('assets', 'Delete Asset'), ['action' => 'delete', $asset->id],
+                ['confirm' => __d('assets', 'Are you sure you want to delete # {0}?', $asset->id), 'class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets', 'List Assets'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <?= $this->Html->link(__d('assets', 'New Asset'), ['action' => 'add'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column-responsive column-80">
@@ -25,51 +25,51 @@
             <?php endif; ?>
             <table>
                 <tr>
-                    <th><?= __d('assets','Id') ?></th>
+                    <th><?= __d('assets', 'Id') ?></th>
                     <td><?= h($asset->id) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Title') ?></th>
+                    <th><?= __d('assets', 'Title') ?></th>
                     <td><?= h($asset->title) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Category') ?></th>
+                    <th><?= __d('assets', 'Category') ?></th>
                     <td><?= h($asset->category) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Filename') ?></th>
+                    <th><?= __d('assets', 'Filename') ?></th>
                     <td><?= h($asset->filename) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Directory') ?></th>
+                    <th><?= __d('assets', 'Directory') ?></th>
                     <td><?= h($asset->directory) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Mimetype') ?></th>
+                    <th><?= __d('assets', 'Mimetype') ?></th>
                     <td><?= h($asset->mimetype) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Filesize') ?></th>
+                    <th><?= __d('assets', 'Filesize') ?></th>
                     <td><?= h($asset->getFileSizeInfo()) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Created') ?></th>
+                    <th><?= __d('assets', 'Created') ?></th>
                     <td><?= h($asset->created) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __d('assets','Modified') ?></th>
+                    <th><?= __d('assets', 'Modified') ?></th>
                     <td><?= h($asset->modified) ?></td>
                 </tr>
             </table>
             <div class="text">
-                <strong><?= __d('assets','Description') ?></strong>
+                <strong><?= __d('assets', 'Description') ?></strong>
                 <blockquote>
                     <?= h($asset->description); ?>
                 </blockquote>
             </div>
             <?php if ($asset->isPlainText()): ?>
                 <div class="text">
-                    <strong><?= __d('assets','Content') ?></strong>
+                    <strong><?= __d('assets', 'Content') ?></strong>
                     <div>
                         <?= $this->TextAssetPreview->plainTextPreview($asset) ?>
                     </div>


### PR DESCRIPTION
`__()` is only meant to be used inside the base app, not inside plugins.

Therefore all plugin vendors should use the domain specific translate method `__d()`, see [HERE](https://book.cakephp.org/4/en/core-libraries/internationalization-and-localization.html#using-translation-functions)

This makes it easier for users to translate text coming from plugin vendors compared to what users have to translate in their own app.

I also cleaned up some strings which had a whitespace at the end or where variables were put into the translatable string via curly brackets.