### PR TITLE
Feature intervention v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"ext-fileinfo": "*",
 		"cakephp/cakephp": "^5.1",
-		"intervention/image": "^3.11",
+		"intervention/image": "^2 || ^3",
 		"josegonzalez/cakephp-upload": "^8",
 		"league/csv": "^9.8",
 		"nette/utils": "^3.2 || ^4.0.0"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"ext-fileinfo": "*",
 		"cakephp/cakephp": "^5.1",
-		"intervention/image": "^2.7.2",
+		"intervention/image": "^3.11",
 		"josegonzalez/cakephp-upload": "^8",
 		"league/csv": "^9.8",
 		"nette/utils": "^3.2 || ^4.0.0"

--- a/src/Error/ModificationFailedException.php
+++ b/src/Error/ModificationFailedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\Error;
+
+use RuntimeException;
+
+final class ModificationFailedException extends RuntimeException
+{
+}

--- a/src/ImageCreation/FilterInterface.php
+++ b/src/ImageCreation/FilterInterface.php
@@ -6,5 +6,7 @@ namespace Assets\ImageCreation;
 
 interface FilterInterface
 {
+    public static function create(ImageManagerInterface $manager, mixed ...$params): FilterInterface;
+
     public function applyFilter(ImageInterface $image): ImageInterface;
 }

--- a/src/ImageCreation/FilterInterface.php
+++ b/src/ImageCreation/FilterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation;
+
+interface FilterInterface
+{
+    public function applyFilter(ImageInterface $image): ImageInterface;
+}

--- a/src/ImageCreation/ImageInterface.php
+++ b/src/ImageCreation/ImageInterface.php
@@ -13,4 +13,9 @@ interface ImageInterface
     public function mime(): string;
 
     public function save(string $absolutePath, ?int $quality, ?string $format): void;
+
+    /**
+     * Modify the image based on the underlying implementation.
+     */
+    public function modify(string $modifier, array $params): self;
 }

--- a/src/ImageCreation/ImageInterface.php
+++ b/src/ImageCreation/ImageInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Assets\ImageCreation;
 
+use Assets\Error\ModificationFailedException;
+
 interface ImageInterface
 {
     public function width(): int;
@@ -16,6 +18,7 @@ interface ImageInterface
 
     /**
      * Modify the image based on the underlying implementation.
+     * @throws ModificationFailedException
      */
     public function modify(string $modifier, array $params): self;
 }

--- a/src/ImageCreation/ImageInterface.php
+++ b/src/ImageCreation/ImageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Assets\ImageCreation;
 
 use Assets\Error\ModificationFailedException;
-use Intervention\Image\Interfaces as Intervention;
 use RuntimeException;
 
 interface ImageInterface
@@ -24,10 +23,14 @@ interface ImageInterface
      */
     public function modify(string $modifier, array $params): self;
 
-    public function getInterventionImage(): ?Intervention\ImageInterface;
+    /**
+     * @return \Intervention\Image\Interfaces\ImageInterface|\Intervention\Image\Image|null
+     */
+    public function getInterventionImage(): ?object;
 
     /**
+     * @return \Intervention\Image\Interfaces\ImageInterface|\Intervention\Image\Image
      * @throws RuntimeException
      */
-    public function requireInterventionImage(): Intervention\ImageInterface;
+    public function requireInterventionImage(): object;
 }

--- a/src/ImageCreation/ImageInterface.php
+++ b/src/ImageCreation/ImageInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation;
+
+interface ImageInterface
+{
+    public function width(): int;
+
+    public function height(): int;
+
+    public function mime(): string;
+
+    public function save(string $absolutePath, ?int $quality, ?string $format): void;
+}

--- a/src/ImageCreation/ImageInterface.php
+++ b/src/ImageCreation/ImageInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Assets\ImageCreation;
 
 use Assets\Error\ModificationFailedException;
+use Intervention\Image\Interfaces as Intervention;
+use RuntimeException;
 
 interface ImageInterface
 {
@@ -21,4 +23,11 @@ interface ImageInterface
      * @throws ModificationFailedException
      */
     public function modify(string $modifier, array $params): self;
+
+    public function getInterventionImage(): ?Intervention\ImageInterface;
+
+    /**
+     * @throws RuntimeException
+     */
+    public function requireInterventionImage(): Intervention\ImageInterface;
 }

--- a/src/ImageCreation/ImageManagerInterface.php
+++ b/src/ImageCreation/ImageManagerInterface.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace Assets\ImageCreation;
 
+use Assets\ImageCreation\Intervention\InterventionImageFacade;
+
 interface ImageManagerInterface
 {
     public function read(string $absolutePath): ImageInterface;
+
+    public function create(int $width, int $height): ImageInterface;
+
+    /**
+     * @deprecated use {@see self::create()}
+     */
+    public function canvas(int $width, int $height): ImageInterface;
 }

--- a/src/ImageCreation/ImageManagerInterface.php
+++ b/src/ImageCreation/ImageManagerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation;
+
+interface ImageManagerInterface
+{
+    public function read(string $absolutePath): ImageInterface;
+}

--- a/src/ImageCreation/ImageManagerLocator.php
+++ b/src/ImageCreation/ImageManagerLocator.php
@@ -45,10 +45,7 @@ final class ImageManagerLocator
     {
         $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
 
-        return new V2\InterventionImageManagerFacade(
-            new ImageManager(['driver' => $driver]),
-            [],
-        );
+        return new V2\InterventionImageManagerFacade(new ImageManager(['driver' => $driver]));
     }
 
     private static function createV3ManagerFacade(): ImageManagerInterface

--- a/src/ImageCreation/ImageManagerLocator.php
+++ b/src/ImageCreation/ImageManagerLocator.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Assets\ImageCreation;
 
 use Assets\ImageCreation\Intervention\InterventionImageManagerFacade;
+use Assets\ImageCreation\LegacyV2Intervention as V2;
 use Assets\ImageCreation\Intervention\LegacySupport;
 use Cake\Core\Configure;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\ImageManager;
+use LogicException;
 
 final class ImageManagerLocator
 {
@@ -21,10 +23,40 @@ final class ImageManagerLocator
             return self::$manager;
         }
 
+        if (interface_exists('\Intervention\Image\Interfaces\ImageInterface')) {
+            return self::$manager = self::createV3ManagerFacade();
+        }
+
+        if (class_exists('\Intervention\Image\ImageManager')) {
+            return self::$manager = self::createV2ManagerFacade();
+        }
+
+        throw new LogicException(
+            'intervention/image must be installed in v2 or v3',
+        );
+    }
+
+    public static function setImageManager(ImageManagerInterface $manager): void
+    {
+        self::$manager = $manager;
+    }
+
+    private static function createV2ManagerFacade(): ImageManagerInterface
+    {
+        $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
+
+        return new V2\InterventionImageManagerFacade(
+            new ImageManager(['driver' => $driver]),
+            [],
+        );
+    }
+
+    private static function createV3ManagerFacade(): ImageManagerInterface
+    {
         $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
         $legacyModifiersMap = Configure::read('AssetsPlugin.ImageAsset.legacyModifiersMap');
 
-        return self::$manager = new InterventionImageManagerFacade(
+        return new InterventionImageManagerFacade(
             match ($driver) {
                 'imagick',
                 ImagickDriver::class => ImageManager::imagick(
@@ -34,16 +66,11 @@ final class ImageManagerLocator
                 GdDriver::class => ImageManager::gd(
                     ...Configure::read('AssetsPlugin.ImageAsset.gdOptions', []),
                 ),
-                default => throw new \LogicException('no driver configured'),
+                default => throw new LogicException('no driver configured'),
             },
             legacyModifiersMap: $legacyModifiersMap !== null
                 ? $legacyModifiersMap
                 : LegacySupport::V2_TO_V3_MODIFIERS_MAP,
         );
-    }
-
-    public static function setImageManager(ImageManagerInterface $manager): void
-    {
-        self::$manager = $manager;
     }
 }

--- a/src/ImageCreation/ImageManagerLocator.php
+++ b/src/ImageCreation/ImageManagerLocator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Assets\ImageCreation;
 
 use Assets\ImageCreation\Intervention\InterventionImageManagerFacade;
+use Assets\ImageCreation\Intervention\LegacySupport;
 use Cake\Core\Configure;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
@@ -21,22 +22,24 @@ final class ImageManagerLocator
         }
 
         $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
+        $legacyModifiersMap = Configure::read('AssetsPlugin.ImageAsset.legacyModifiersMap');
 
-        $manager = self::$manager = new InterventionImageManagerFacade(
+        return self::$manager = new InterventionImageManagerFacade(
             match ($driver) {
                 'imagick',
                 ImagickDriver::class => ImageManager::imagick(
-                    options: Configure::read('AssetsPlugin.ImageAsset.imagickOptions', []),
+                    ...Configure::read('AssetsPlugin.ImageAsset.imagickOptions', []),
                 ),
                 'gd',
                 GdDriver::class => ImageManager::gd(
-                    options: Configure::read('AssetsPlugin.ImageAsset.gdOptions', []),
+                    ...Configure::read('AssetsPlugin.ImageAsset.gdOptions', []),
                 ),
                 default => throw new \LogicException('no driver configured'),
             },
+            legacyModifiersMap: $legacyModifiersMap !== null
+                ? $legacyModifiersMap
+                : LegacySupport::V2_TO_V3_MODIFIERS_MAP,
         );
-
-        return $manager;
     }
 
     public static function setImageManager(ImageManagerInterface $manager): void

--- a/src/ImageCreation/ImageManagerLocator.php
+++ b/src/ImageCreation/ImageManagerLocator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation;
+
+use Assets\ImageCreation\Intervention\InterventionImageManagerFacade;
+use Cake\Core\Configure;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\ImageManager;
+
+final class ImageManagerLocator
+{
+    private static ?ImageManagerInterface $manager = null;
+
+    public static function getImageManager(): ImageManagerInterface
+    {
+        if (self::$manager !== null) {
+            return self::$manager;
+        }
+
+        $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
+
+        $manager = self::$manager = new InterventionImageManagerFacade(
+            match ($driver) {
+                'imagick',
+                ImagickDriver::class => ImageManager::imagick(
+                    options: Configure::read('AssetsPlugin.ImageAsset.imagickOptions', []),
+                ),
+                'gd',
+                GdDriver::class => ImageManager::gd(
+                    options: Configure::read('AssetsPlugin.ImageAsset.gdOptions', []),
+                ),
+                default => throw new \LogicException('no driver configured'),
+            },
+        );
+
+        return $manager;
+    }
+
+    public static function setImageManager(ImageManagerInterface $manager): void
+    {
+        self::$manager = $manager;
+    }
+}

--- a/src/ImageCreation/Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageFacade.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Assets\ImageCreation\Intervention;
 
+use Assets\Error\InvalidArgumentException;
 use Assets\ImageCreation\ImageInterface;
 use Intervention\Image\MediaType;
 use Intervention\Image\Interfaces as Intervention;
 
 final class InterventionImageFacade implements ImageInterface
 {
+    /**
+     * @param array<string, string> $legacyMdifiersMap
+     */
     public function __construct(
-        private Intervention\ImageInterface $interventionImage
+        private Intervention\ImageInterface $interventionImage,
+        private array                       $legacyMdifiersMap,
     ) {
     }
 
@@ -40,5 +45,30 @@ final class InterventionImageFacade implements ImageInterface
         }
 
         $this->interventionImage->save($absolutePath, quality: $quality);
+    }
+
+    public function modify(string $modifier, array $params): ImageInterface
+    {
+        if (method_exists($this->interventionImage, $modifier)) {
+            $this->interventionImage->{$modifier}(...$params);
+            return $this;
+        }
+
+        $mappedFromLegacy = $this->legacyMdifiersMap[$modifier] ?? null;
+
+        if (
+            $mappedFromLegacy !== null
+            && method_exists($this->interventionImage, $mappedFromLegacy)
+        ) {
+            $this->interventionImage->{$mappedFromLegacy}(...$params);
+            return $this;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf(
+                'Modifier `%s` does not exist',
+                $modifier,
+            ),
+        );
     }
 }

--- a/src/ImageCreation/Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageFacade.php
@@ -104,4 +104,14 @@ final class InterventionImageFacade implements ImageInterface
 
         throw new ModificationFailedException(sprintf('Modifier `%s` does not exist', $modifier));
     }
+
+    public function getInterventionImage(): Intervention\ImageInterface
+    {
+        return $this->requireInterventionImage();
+    }
+
+    public function requireInterventionImage(): Intervention\ImageInterface
+    {
+        return $this->interventionImage;
+    }
 }

--- a/src/ImageCreation/Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageFacade.php
@@ -9,6 +9,7 @@ use Assets\Error\ModificationFailedException;
 use Assets\ImageCreation\ImageInterface;
 use Intervention\Image\MediaType;
 use Intervention\Image\Interfaces as Intervention;
+use Nette\Utils\FileSystem;
 
 final class InterventionImageFacade implements ImageInterface
 {
@@ -42,8 +43,14 @@ final class InterventionImageFacade implements ImageInterface
 
     public function save(string $absolutePath, ?int $quality, ?string $format): void
     {
-        if ($format !== null) {
-            $absolutePath .= $absolutePath . '.' . $format;
+        if ($format !== null && !str_ends_with($absolutePath, '.' . $format)) {
+            $absolutePath .= '.' . $format;
+        }
+
+        $dir = dirname($absolutePath);
+
+        if (!is_dir($dir)) {
+            FileSystem::createDir($dir);
         }
 
         $this->interventionImage->save($absolutePath, quality: $quality);
@@ -64,6 +71,7 @@ final class InterventionImageFacade implements ImageInterface
                     $callback = $this->legacyMdifiersMap[$modifier] ?? null;
                     if ($callback !== null && is_callable($callback)) {
                         $callback($this->interventionImage, ...$params);
+                        return $this->interventionImage;
                     }
                 }
 

--- a/src/ImageCreation/Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Assets\ImageCreation\Intervention;
 
 use Assets\Error\InvalidArgumentException;
+use Assets\Error\ModificationFailedException;
 use Assets\ImageCreation\ImageInterface;
 use Intervention\Image\MediaType;
 use Intervention\Image\Interfaces as Intervention;
@@ -12,12 +13,13 @@ use Intervention\Image\Interfaces as Intervention;
 final class InterventionImageFacade implements ImageInterface
 {
     /**
-     * @param array<string, string> $legacyMdifiersMap
+     * @param array<string, string|callable> $legacyMdifiersMap
      */
     public function __construct(
         private Intervention\ImageInterface $interventionImage,
         private array                       $legacyMdifiersMap,
-    ) {
+    )
+    {
     }
 
     public function width(): int
@@ -49,8 +51,36 @@ final class InterventionImageFacade implements ImageInterface
 
     public function modify(string $modifier, array $params): ImageInterface
     {
+        if ($params === []) {
+            throw new ModificationFailedException('Empty params given');
+        }
+
+        $modify = function (string $modifier, array $params, ?string $legacyModifier = null) {
+            try {
+                $this->interventionImage->{$modifier}(...$params);
+            } catch (\Throwable $throwable) {
+
+                if ($legacyModifier === null) {
+                    $callback = $this->legacyMdifiersMap[$modifier] ?? null;
+                    if ($callback !== null && is_callable($callback)) {
+                        $callback($this->interventionImage, ...$params);
+                    }
+                }
+
+                throw new ModificationFailedException(
+                    sprintf(
+                        'Modification `%s` failed with params: %s.%s',
+                        $modifier,
+                        var_export($params, true),
+                        $legacyModifier !== null ? ' Legacy: ' . $legacyModifier : '',
+                    ),
+                    previous: $throwable,
+                );
+            }
+        };
+
         if (method_exists($this->interventionImage, $modifier)) {
-            $this->interventionImage->{$modifier}(...$params);
+            $modify($modifier, $params);
             return $this;
         }
 
@@ -60,15 +90,10 @@ final class InterventionImageFacade implements ImageInterface
             $mappedFromLegacy !== null
             && method_exists($this->interventionImage, $mappedFromLegacy)
         ) {
-            $this->interventionImage->{$mappedFromLegacy}(...$params);
+            $modify($mappedFromLegacy, $params, $modifier);
             return $this;
         }
 
-        throw new InvalidArgumentException(
-            sprintf(
-                'Modifier `%s` does not exist',
-                $modifier,
-            ),
-        );
+        throw new ModificationFailedException(sprintf('Modifier `%s` does not exist', $modifier));
     }
 }

--- a/src/ImageCreation/Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageFacade.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation\Intervention;
+
+use Assets\ImageCreation\ImageInterface;
+use Intervention\Image\MediaType;
+use Intervention\Image\Interfaces as Intervention;
+
+final class InterventionImageFacade implements ImageInterface
+{
+    public function __construct(
+        private Intervention\ImageInterface $interventionImage
+    ) {
+    }
+
+    public function width(): int
+    {
+        return $this->interventionImage->width();
+    }
+
+    public function height(): int
+    {
+        return $this->interventionImage->height();
+    }
+
+    /**
+     * @see MediaType
+     */
+    public function mime(): string
+    {
+        return $this->interventionImage->origin()->mediaType();
+    }
+
+    public function save(string $absolutePath, ?int $quality, ?string $format): void
+    {
+        if ($format !== null) {
+            $absolutePath .= $absolutePath . '.' . $format;
+        }
+
+        $this->interventionImage->save($absolutePath, quality: $quality);
+    }
+}

--- a/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
@@ -26,4 +26,17 @@ final class InterventionImageManagerFacade implements ImageManagerInterface
             $this->legacyModifiersMap,
         );
     }
+
+    public function create(int $width, int $height): ImageInterface
+    {
+        return new InterventionImageFacade(
+            $this->interventionImageManager->create($width, $height),
+            $this->legacyModifiersMap,
+        );
+    }
+
+    public function canvas(int $width, int $height): ImageInterface
+    {
+        return $this->create($width, $height);
+    }
 }

--- a/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation\Intervention;
+
+use Assets\ImageCreation\ImageInterface;
+use Assets\ImageCreation\ImageManagerInterface;
+use Intervention\Image\Interfaces as Intervention;
+
+final class InterventionImageManagerFacade implements ImageManagerInterface
+{
+    public function __construct(
+        private Intervention\ImageManagerInterface $interventionImageManager,
+    ) {
+    }
+
+    public function read(string $absolutePath): ImageInterface
+    {
+        return new InterventionImageFacade(
+            $this->interventionImageManager->read($absolutePath),
+        );
+    }
+}

--- a/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
@@ -11,7 +11,7 @@ use Intervention\Image\Interfaces as Intervention;
 final class InterventionImageManagerFacade implements ImageManagerInterface
 {
     /**
-     * @param array<string, string> $legacyModifiersMap
+     * @param array<string, string|callable> $legacyModifiersMap
      */
     public function __construct(
         private Intervention\ImageManagerInterface $interventionImageManager,

--- a/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/Intervention/InterventionImageManagerFacade.php
@@ -10,8 +10,12 @@ use Intervention\Image\Interfaces as Intervention;
 
 final class InterventionImageManagerFacade implements ImageManagerInterface
 {
+    /**
+     * @param array<string, string> $legacyModifiersMap
+     */
     public function __construct(
         private Intervention\ImageManagerInterface $interventionImageManager,
+        private array $legacyModifiersMap,
     ) {
     }
 
@@ -19,6 +23,7 @@ final class InterventionImageManagerFacade implements ImageManagerInterface
     {
         return new InterventionImageFacade(
             $this->interventionImageManager->read($absolutePath),
+            $this->legacyModifiersMap,
         );
     }
 }

--- a/src/ImageCreation/Intervention/LegacySupport.php
+++ b/src/ImageCreation/Intervention/LegacySupport.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation\Intervention;
+
+final class LegacySupport
+{
+    /**
+     * @see https://image.intervention.io/v3/getting-started/upgrade
+     *
+     * Note: Signature might have changed.
+     */
+    public const V2_TO_V3_MODIFIERS_MAP = [
+        'canvas'     => 'create',
+        'circle'     => 'drawCircle',
+        'ellipse'    => 'drawEllipse',
+        'line'       => 'drawLine',
+        'pixel'      => 'drawPixel',
+        'filter'     => 'modify',
+        'insert'     => 'place',
+        'make'       => 'read',
+        'mime'       => 'encodedImage',
+        'polygon'    => 'drawPolygon',
+        'rectangle'  => 'drawRectangle',
+        'limitColors'=> 'reduceColors',
+        'getCore'    => 'core',
+        'orientate'  => 'orient',
+        'widen'      => 'scale',
+        'heighten'   => 'scale',
+        'fit'        => 'cover',
+    ];
+}

--- a/src/ImageCreation/Intervention/LegacySupport.php
+++ b/src/ImageCreation/Intervention/LegacySupport.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Assets\ImageCreation\Intervention;
 
+use Assets\Error\ModificationFailedException;
+use Intervention\Image\Image;
+
 final class LegacySupport
 {
     /**
@@ -12,22 +15,78 @@ final class LegacySupport
      * Note: Signature might have changed.
      */
     public const V2_TO_V3_MODIFIERS_MAP = [
-        'canvas'     => 'create',
-        'circle'     => 'drawCircle',
-        'ellipse'    => 'drawEllipse',
-        'line'       => 'drawLine',
-        'pixel'      => 'drawPixel',
-        'filter'     => 'modify',
-        'insert'     => 'place',
-        'make'       => 'read',
-        'mime'       => 'encodedImage',
-        'polygon'    => 'drawPolygon',
-        'rectangle'  => 'drawRectangle',
-        'limitColors'=> 'reduceColors',
-        'getCore'    => 'core',
-        'orientate'  => 'orient',
-        'widen'      => 'scale',
-        'heighten'   => 'scale',
-        'fit'        => 'cover',
+        // Name changed
+        'canvas' => 'create',
+        'circle' => 'drawCircle',
+        'ellipse' => 'drawEllipse',
+        'line' => 'drawLine',
+        'pixel' => 'drawPixel',
+        'filter' => 'modify',
+        'insert' => 'place',
+        'make' => 'read',
+        'mime' => 'encodedImage',
+        'polygon' => 'drawPolygon',
+        'rectangle' => 'drawRectangle',
+        'limitColors' => 'reduceColors',
+        'getCore' => 'core',
+        'orientate' => 'orient',
+        'widen' => 'scale',
+        'heighten' => 'scale',
+        'fit' => 'cover',
+        // Signature changed
+        'crop' => [self::class, 'legacyCrop'],
+        'encode' => [self::class, 'legacyEncode'],
+        'exif' => [self::class, 'legacyExif'],
+        'fill' => [self::class, 'legacyFill'],
+        'flip' => [self::class, 'legacyFlip'],
+        'text' => [self::class, 'legacyText'],
+        'resizeCanvas' => [self::class, 'legacyResizeCanvas'],
+        'trim' => [self::class, 'legacyTrim'],
+        'resize' => [self::class, 'legacyResize'],
     ];
+
+    public static function legacyCrop(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for crop not implemented');
+    }
+
+    public static function legacyEncode(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for encode not implemented');
+    }
+
+    public static function legacyExif(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for exif not implemented');
+    }
+
+    public static function legacyFill(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for fill not implemented');
+    }
+
+    public static function legacyFlip(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for flip not implemented');
+    }
+
+    public static function legacyText(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for text not implemented');
+    }
+
+    public static function legacyResizeCanvas(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for resizeCanvas not implemented');
+    }
+
+    public static function legacyTrim(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for trim not implemented');
+    }
+
+    public static function legacyResize(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for resize not implemented');
+    }
 }

--- a/src/ImageCreation/Intervention/LegacySupport.php
+++ b/src/ImageCreation/Intervention/LegacySupport.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Assets\ImageCreation\Intervention;
 
 use Assets\Error\ModificationFailedException;
+use Intervention\Image\Encoders\FileExtensionEncoder;
+use Intervention\Image\FileExtension;
 use Intervention\Image\Image;
+use Intervention\Image\Interfaces\EncodedImageInterface;
 
 final class LegacySupport
 {
@@ -50,9 +53,17 @@ final class LegacySupport
         throw new ModificationFailedException('legacy fallback for crop not implemented');
     }
 
-    public static function legacyEncode(Image $image, mixed ...$params): Image
+    public static function legacyEncode(Image $image, mixed ...$params): EncodedImageInterface
     {
-        throw new ModificationFailedException('legacy fallback for encode not implemented');
+        $format = $params[0] ?? null;
+
+        if (!is_string($format)) {
+            throw new ModificationFailedException('no format given');
+        }
+
+        $encoder = new FileExtensionEncoder(FileExtension::from($format));
+
+        return $image->encode($encoder);
     }
 
     public static function legacyExif(Image $image, mixed ...$params): Image

--- a/src/ImageCreation/LegacyV2Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/LegacyV2Intervention/InterventionImageFacade.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Assets\ImageCreation\Intervention;
+namespace Assets\ImageCreation\LegacyV2Intervention;
 
 use Assets\Error\InvalidArgumentException;
 use Assets\Error\ModificationFailedException;
 use Assets\ImageCreation\ImageInterface;
+use Intervention\Image\Image;
 use Intervention\Image\MediaType;
 use Intervention\Image\Interfaces as Intervention;
 use Nette\Utils\FileSystem;
@@ -17,7 +18,7 @@ final class InterventionImageFacade implements ImageInterface
      * @param array<string, string|callable> $legacyMdifiersMap
      */
     public function __construct(
-        private Intervention\ImageInterface $interventionImage,
+        private Image $interventionImage,
         private array                       $legacyMdifiersMap,
     ) {
     }

--- a/src/ImageCreation/LegacyV2Intervention/InterventionImageFacade.php
+++ b/src/ImageCreation/LegacyV2Intervention/InterventionImageFacade.php
@@ -4,23 +4,17 @@ declare(strict_types=1);
 
 namespace Assets\ImageCreation\LegacyV2Intervention;
 
-use Assets\Error\InvalidArgumentException;
 use Assets\Error\ModificationFailedException;
 use Assets\ImageCreation\ImageInterface;
 use Intervention\Image\Image;
 use Intervention\Image\MediaType;
-use Intervention\Image\Interfaces as Intervention;
 use Nette\Utils\FileSystem;
 
 final class InterventionImageFacade implements ImageInterface
 {
-    /**
-     * @param array<string, string|callable> $legacyMdifiersMap
-     */
     public function __construct(
         private Image $interventionImage,
-        private array                       $legacyMdifiersMap,
-    ) {
+    )  {
     }
 
     public function width(): int
@@ -62,55 +56,30 @@ final class InterventionImageFacade implements ImageInterface
             throw new ModificationFailedException('Empty params given');
         }
 
-        $modify = function (string $modifier, array $params, ?string $legacyModifier = null) {
-            try {
+        try {
+            if (method_exists($this->interventionImage, $modifier)) {
                 $this->interventionImage->{$modifier}(...$params);
-            } catch (\Throwable $throwable) {
-
-                if ($legacyModifier === null) {
-                    $callback = $this->legacyMdifiersMap[$modifier] ?? null;
-                    if ($callback !== null && is_callable($callback)) {
-                        $callback($this->interventionImage, ...$params);
-                        return $this->interventionImage;
-                    }
-                }
-
-                throw new ModificationFailedException(
-                    sprintf(
-                        'Modification `%s` failed with params: %s.%s',
-                        $modifier,
-                        var_export($params, true),
-                        $legacyModifier !== null ? ' Legacy: ' . $legacyModifier : '',
-                    ),
-                    previous: $throwable,
-                );
             }
-        };
-
-        if (method_exists($this->interventionImage, $modifier)) {
-            $modify($modifier, $params);
-            return $this;
-        }
-
-        $mappedFromLegacy = $this->legacyMdifiersMap[$modifier] ?? null;
-
-        if (
-            $mappedFromLegacy !== null
-            && method_exists($this->interventionImage, $mappedFromLegacy)
-        ) {
-            $modify($mappedFromLegacy, $params, $modifier);
-            return $this;
+        } catch (\Throwable $throwable) {
+            throw new ModificationFailedException(
+                sprintf(
+                    'Modification `%s` failed with params: %s.',
+                    $modifier,
+                    var_export($params, true),
+                ),
+                previous: $throwable,
+            );
         }
 
         throw new ModificationFailedException(sprintf('Modifier `%s` does not exist', $modifier));
     }
 
-    public function getInterventionImage(): Intervention\ImageInterface
+    public function getInterventionImage(): Image
     {
-        return $this->requireInterventionImage();
+        return $this->interventionImage;
     }
 
-    public function requireInterventionImage(): Intervention\ImageInterface
+    public function requireInterventionImage(): Image
     {
         return $this->interventionImage;
     }

--- a/src/ImageCreation/LegacyV2Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/LegacyV2Intervention/InterventionImageManagerFacade.php
@@ -10,12 +10,8 @@ use Intervention\Image\ImageManager;
 
 final class InterventionImageManagerFacade implements ImageManagerInterface
 {
-    /**
-     * @param array<string, string|callable> $legacyModifiersMap
-     */
     public function __construct(
         private ImageManager $interventionImageManager,
-        private array $legacyModifiersMap,
     ) {
     }
 
@@ -23,7 +19,6 @@ final class InterventionImageManagerFacade implements ImageManagerInterface
     {
         return new InterventionImageFacade(
             $this->interventionImageManager->make($absolutePath),
-            $this->legacyModifiersMap,
         );
     }
 
@@ -31,7 +26,6 @@ final class InterventionImageManagerFacade implements ImageManagerInterface
     {
         return new InterventionImageFacade(
             $this->interventionImageManager->canvas($width, $height),
-            $this->legacyModifiersMap,
         );
     }
 

--- a/src/ImageCreation/LegacyV2Intervention/InterventionImageManagerFacade.php
+++ b/src/ImageCreation/LegacyV2Intervention/InterventionImageManagerFacade.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation\LegacyV2Intervention;
+
+use Assets\ImageCreation\ImageInterface;
+use Assets\ImageCreation\ImageManagerInterface;
+use Intervention\Image\ImageManager;
+
+final class InterventionImageManagerFacade implements ImageManagerInterface
+{
+    /**
+     * @param array<string, string|callable> $legacyModifiersMap
+     */
+    public function __construct(
+        private ImageManager $interventionImageManager,
+        private array $legacyModifiersMap,
+    ) {
+    }
+
+    public function read(string $absolutePath): ImageInterface
+    {
+        return new InterventionImageFacade(
+            $this->interventionImageManager->make($absolutePath),
+            $this->legacyModifiersMap,
+        );
+    }
+
+    public function create(int $width, int $height): ImageInterface
+    {
+        return new InterventionImageFacade(
+            $this->interventionImageManager->canvas($width, $height),
+            $this->legacyModifiersMap,
+        );
+    }
+
+    public function canvas(int $width, int $height): ImageInterface
+    {
+        return $this->create($width, $height);
+    }
+}

--- a/src/ImageCreation/LegacyV2Intervention/LegacySupport.php
+++ b/src/ImageCreation/LegacyV2Intervention/LegacySupport.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\ImageCreation\LegacyV2Intervention;
+
+use Assets\Error\ModificationFailedException;
+use Intervention\Image\Encoders\FileExtensionEncoder;
+use Intervention\Image\FileExtension;
+use Intervention\Image\Image;
+use Intervention\Image\Interfaces\EncodedImageInterface;
+
+final class LegacySupport
+{
+    /**
+     * @see https://image.intervention.io/v3/getting-started/upgrade
+     *
+     * Note: Signature might have changed.
+     */
+    public const V2_TO_V3_MODIFIERS_MAP = [
+        // Name changed
+        'canvas' => 'create',
+        'circle' => 'drawCircle',
+        'ellipse' => 'drawEllipse',
+        'line' => 'drawLine',
+        'pixel' => 'drawPixel',
+        'filter' => 'modify',
+        'insert' => 'place',
+        'make' => 'read',
+        'mime' => 'encodedImage',
+        'polygon' => 'drawPolygon',
+        'rectangle' => 'drawRectangle',
+        'limitColors' => 'reduceColors',
+        'getCore' => 'core',
+        'orientate' => 'orient',
+        'widen' => 'scale',
+        'heighten' => 'scale',
+        'fit' => 'cover',
+        // Signature changed
+        'crop' => [self::class, 'legacyCrop'],
+        'encode' => [self::class, 'legacyEncode'],
+        'exif' => [self::class, 'legacyExif'],
+        'fill' => [self::class, 'legacyFill'],
+        'flip' => [self::class, 'legacyFlip'],
+        'text' => [self::class, 'legacyText'],
+        'resizeCanvas' => [self::class, 'legacyResizeCanvas'],
+        'trim' => [self::class, 'legacyTrim'],
+        'resize' => [self::class, 'legacyResize'],
+    ];
+
+    public static function legacyCrop(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for crop not implemented');
+    }
+
+    public static function legacyEncode(Image $image, mixed ...$params): EncodedImageInterface
+    {
+        $format = $params[0] ?? null;
+
+        if (!is_string($format)) {
+            throw new ModificationFailedException('no format given');
+        }
+
+        $encoder = new FileExtensionEncoder(FileExtension::from($format));
+
+        return $image->encode($encoder);
+    }
+
+    public static function legacyExif(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for exif not implemented');
+    }
+
+    public static function legacyFill(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for fill not implemented');
+    }
+
+    public static function legacyFlip(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for flip not implemented');
+    }
+
+    public static function legacyText(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for text not implemented');
+    }
+
+    public static function legacyResizeCanvas(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for resizeCanvas not implemented');
+    }
+
+    public static function legacyTrim(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for trim not implemented');
+    }
+
+    public static function legacyResize(Image $image, mixed ...$params): Image
+    {
+        throw new ModificationFailedException('legacy fallback for resize not implemented');
+    }
+}

--- a/src/Utilities/ImageAsset.php
+++ b/src/Utilities/ImageAsset.php
@@ -207,7 +207,8 @@ final class ImageAsset
         if (!is_a($filter, FilterInterface::class, allow_string: true)) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Argument $filter of type `%s` does not implement `%s`.',
+                    'Argument $filter (`%s`) of type `%s` does not implement `%s`.',
+                    \Cake\Core\h($filter),
                     get_debug_type($filter),
                     FilterInterface::class,
                 ),

--- a/src/Utilities/ImageAsset.php
+++ b/src/Utilities/ImageAsset.php
@@ -464,7 +464,7 @@ final class ImageAsset
             }
 
             $params = is_array($params) ? $params : [$params];
-            $image->{$method}(...$params);
+            $image->modify($method, $params);
         }
 
         return $image;

--- a/src/Utilities/ImageAsset.php
+++ b/src/Utilities/ImageAsset.php
@@ -458,8 +458,7 @@ final class ImageAsset
                     );
                 }
 
-                $filter = new $filterClassName($manager, ...$params);
-                $image = $filter->applyFilter($image);
+                $image = $filterClassName::create($manager, ...$params)->applyFilter($image);
                 continue;
             }
 

--- a/src/Utilities/ImageAsset.php
+++ b/src/Utilities/ImageAsset.php
@@ -6,14 +6,16 @@ namespace Assets\Utilities;
 use Assets\Error\FileNotFoundException;
 use Assets\Error\FilterNotFoundException;
 use Assets\Error\UnkownErrorException;
+use Assets\ImageCreation\FilterInterface;
+use Assets\ImageCreation\ImageInterface;
+use Assets\ImageCreation\ImageManagerInterface;
+use Assets\ImageCreation\ImageManagerLocator;
 use Assets\Model\Entity\Asset;
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\View;
 use Exception;
-use Intervention\Image\Image;
-use Intervention\Image\ImageManager;
 use InvalidArgumentException;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
@@ -29,7 +31,7 @@ use SplFileInfo;
  *
  * To just get a public path from /webroot, call getPath()
  */
-class ImageAsset
+final class ImageAsset
 {
     private Asset $asset;
 
@@ -41,11 +43,11 @@ class ImageAsset
 
     private array $modifications;
 
-    private ?Image $image;
+    private ?ImageInterface $image = null;
 
     private ?string $format;
 
-    private ?string $filename;
+    private ?string $filename = null;
 
     private string $css;
 
@@ -62,7 +64,6 @@ class ImageAsset
         $this->asset = $asset;
         $this->quality = $quality;
         $this->modifications = [];
-        $this->image = null;
         $this->format = $this->asset->filetype;
         $this->filename = null;
         $this->lazyLoading = true;
@@ -82,8 +83,8 @@ class ImageAsset
      * @param array $options - optional:
      * - title (string): for alt-parameter in html-output
      * - quality (int): for jpg compression
-     * @throws \InvalidArgumentException when no file was found
      * @return self
+     * @throws InvalidArgumentException when no file was found
      */
     public static function createFromPath(string $path, array $options = []): self
     {
@@ -117,7 +118,7 @@ class ImageAsset
 
         $quality = $options['quality'] ?? 90;
 
-        return new ImageAsset($asset, (int)$quality);
+        return new self($asset, (int)$quality);
     }
 
     /**
@@ -127,7 +128,7 @@ class ImageAsset
      * @param int $width Width in px
      * @return $this
      */
-    public function scaleWidth(int $width)
+    public function scaleWidth(int $width): self
     {
         $this->trackModification('widen', [$width]);
 
@@ -137,7 +138,7 @@ class ImageAsset
     /**
      * @return $this
      */
-    public function toWebp()
+    public function toWebp(): self
     {
         $this->trackModification('encode', ['webp']);
         $this->format = 'webp';
@@ -148,7 +149,7 @@ class ImageAsset
     /**
      * @return $this
      */
-    public function toJpg()
+    public function toJpg(): self
     {
         $this->trackModification('encode', ['jpg']);
         $this->format = 'jpg';
@@ -162,7 +163,7 @@ class ImageAsset
      * @param string $css HTML class which will be added on render
      * @return $this
      */
-    public function setCSS(string $css)
+    public function setCSS(string $css): self
     {
         $this->css = $css;
 
@@ -173,7 +174,7 @@ class ImageAsset
      * @param bool $lazyLoading Control if the image shall be loaded lazily when rendered as Html
      * @return $this
      */
-    public function setLazyLoading(bool $lazyLoading = true)
+    public function setLazyLoading(bool $lazyLoading = true): self
     {
         $this->lazyLoading = $lazyLoading;
 
@@ -189,7 +190,7 @@ class ImageAsset
      * @param string|null $filename the custom filename
      * @return $this
      */
-    public function setFilename(?string $filename)
+    public function setFilename(?string $filename): self
     {
         $this->filename = $filename;
 
@@ -197,16 +198,22 @@ class ImageAsset
     }
 
     /**
-     * e.g.
-     * ImageAsset::applyFilter(EpaperFilter::class, ['kombi'])
-     * !! Don't pass an ImageManager instance, only string or int properties.
-     *
      * @param string $filter ClassName of the Filter
-     * @param array $properties Will be passed after the ImageManager instance when calling the Filter's constructor.
+     * @param array $properties Will be passed to the Filter's constructor
      * @return $this
      */
-    public function applyFilter(string $filter, array $properties = [])
+    public function applyFilter(string $filter, array $properties = []): self
     {
+        if (!is_a($filter, FilterInterface::class, allow_string: true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Argument $filter of type `%s` does not implement `%s`.',
+                    get_debug_type($filter),
+                    FilterInterface::class,
+                ),
+            );
+        }
+
         $this->trackModification('filter_' . $filter, $properties);
 
         return $this;
@@ -221,7 +228,7 @@ class ImageAsset
      * @return $this
      * @link https://image.intervention.io/v2
      */
-    public function modify(string $method, mixed ...$params)
+    public function modify(string $method, mixed ...$params): self
     {
         $this->trackModification($method, $params);
 
@@ -262,7 +269,7 @@ class ImageAsset
 
         if (!$this->image) {
             $manager = $this->getImageManager();
-            $this->image = $manager->make($this->getAbsolutePath());
+            $this->image = $manager->read($this->getAbsolutePath());
         }
 
         $default_params = [
@@ -407,7 +414,7 @@ class ImageAsset
         $manager = $this->getImageManager();
 
         try {
-            $image = $manager->make($this->asset->absolute_path);
+            $image = $manager->read($this->asset->absolute_path);
         } catch (Exception $e) {
             throw new UnkownErrorException("Could not call ImageManager::make on Asset #{$this->asset->id}. Error: {$e->getMessage()}.");
         }
@@ -423,12 +430,9 @@ class ImageAsset
     }
 
     /**
-     * @param \Intervention\Image\Image $image The image instance
-     * @param \Intervention\Image\ImageManager $manager The manager instance
-     * @return \Intervention\Image\Image
      * @throws \Assets\Error\FilterNotFoundException
      */
-    private function applyModifications(Image $image, ImageManager $manager): Image
+    private function applyModifications(ImageInterface $image, ImageManagerInterface $manager): ImageInterface
     {
         $modifications = $this->modifications;
         unset($modifications['noApi']);
@@ -437,12 +441,23 @@ class ImageAsset
             if (str_contains($method, 'filter_')) {
                 $filterClassName = Strings::after($method, 'filter_') ?? '';
                 if (!class_exists($filterClassName)) {
-                    throw new FilterNotFoundException("Filter {$filterClassName} does not exist. ");
+                    throw new FilterNotFoundException(
+                        sprintf(
+                            'Filter `%s` does not exist.',
+                            $filterClassName,
+                        ),
+                    );
+                }
+                if (!is_a($filterClassName, FilterInterface::class, allow_string: true)) {
+                    throw new FilterNotFoundException(
+                        sprintf(
+                            'Filter `%s` does not implement `%s`.',
+                            $filterClassName,
+                            FilterInterface::class,
+                        ),
+                    );
                 }
 
-                /**
-                 * @var \Intervention\Image\Filters\FilterInterface $filter
-                 */
                 $filter = new $filterClassName($manager, ...$params);
                 $image = $filter->applyFilter($image);
                 continue;
@@ -455,15 +470,8 @@ class ImageAsset
         return $image;
     }
 
-    /**
-     * @return \Intervention\Image\ImageManager
-     */
-    private function getImageManager(): ImageManager
+    private function getImageManager(): ImageManagerInterface
     {
-        $driver = Configure::read('AssetsPlugin.ImageAsset.driver', 'gd');
-
-        return new ImageManager([
-            'driver' => $driver,
-        ]);
+        return ImageManagerLocator::getImageManager();
     }
 }


### PR DESCRIPTION
Adds support for intervention/image v3.
https://github.com/brandcom/cakephp-assets/issues/13 

And some backwards-compatibility functionality, e.g. mapping of legacy modifier names and callbacks to wrap modifiers that have the same name but changed their signature.

This PR has some out-of-the-box support for v2 and allows both versions. Support for v2 will be dropped in a future release.